### PR TITLE
Fix nrst pin assignments and output

### DIFF
--- a/include/board_pico_config.h
+++ b/include/board_pico_config.h
@@ -40,8 +40,8 @@
 #endif
 
 // UART config
-#define PROBE_UART_TX 8
-#define PROBE_UART_RX 9
+#define PROBE_UART_TX 4
+#define PROBE_UART_RX 5
 #define PROBE_UART_INTERFACE uart1
 #define PROBE_UART_BAUDRATE 115200
 

--- a/include/board_pico_config.h
+++ b/include/board_pico_config.h
@@ -36,7 +36,7 @@
 #define PROBE_PIN_SWDIO (PROBE_PIN_OFFSET + 1) // 3
 // Target reset config
 #if false
-#define PROBE_PIN_RESET (PROBE_PIN_OFFSET + 2) // 4
+#define PROBE_PIN_RESET 1
 #endif
 
 // UART config

--- a/src/main.c
+++ b/src/main.c
@@ -85,9 +85,9 @@ int main(void) {
     usb_serial_init();
     cdc_uart_init();
     tusb_init();
+    stdio_uart_init();
 
     DAP_Setup();
-    stdio_uart_init();
 
     led_init();
 


### PR DESCRIPTION
This fixes the reset output so that it works. I've tested it with a target running an STM32F429 and openocd. I ran openocd with:

```sh
$ openocd -f interface/cmsis-dap.cfg -c 'transport select swd' -c 'reset_config srst_only srst_open_drain' -f 'target/stm32f4x.cfg' -c 'init' -c 'reset' -c 'exit'
```

I see similar output when using gdb and running `mon reset halt` or just `mon reset`.

"Ringing" can be seen on the reset line with the existing patch, and it doesn't work. This is output from a device that is undergoing a self-reset:

![Screenshot_2024-03-18-14-05-50](https://github.com/geekman/debugprobe-dev/assets/238325/3386839c-c0e9-4ea3-833f-781439e6e9dc)

By moving `stdio_uart_init()` to before `DAP_Setup()` we ensure the pin doesn't get remuxed, and we get a nice clean output:

![Screenshot_2024-03-18-15-18-46](https://github.com/geekman/debugprobe-dev/assets/238325/aa31d7cc-c41c-4871-90b2-cc68571471b6)

This patchset also removes any pulls that appear which, in my experience, can sometimes cause undesired behaviour in the target.
